### PR TITLE
🛠️ Build Dependabot updates

### DIFF
--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout Pull Request
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -45,6 +47,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -4,19 +4,15 @@ on:
   pull_request:
 
 jobs:
-  build-dependencies:
+  build:
     #         PR was opened by Dependabot                           PR has 'javascript' label
     if: ${{ github.actor == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'javascript') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Checkout Pull Request
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          persists-credentials: false
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -29,6 +25,32 @@ jobs:
 
       - name: Build and package
         run: npm run all
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 1
+
+  commit-artifacts:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Commit and push build artifacts
         run: |

--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm ci
 
       - name: Build and package
-        run: npm run all
+        run: npm run build && npm run package
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     #                   PR was opened by Dependabot                                      PR has 'javascript' label
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'javascript') }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'javascript') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   build:
-    #         PR was opened by Dependabot                           PR has 'javascript' label
-    if: ${{ github.actor == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'javascript') }}
+    #                   PR was opened by Dependabot                                      PR has 'javascript' label
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'javascript') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -1,0 +1,38 @@
+name: Compile Dependabot Updates
+
+on:
+  pull_request:
+
+jobs:
+  build-dependencies:
+    #         PR was opened by Dependabot                           PR has 'javascript' label
+    if: ${{ github.actor == 'dependabot[bot]' && contains(join(github.event.pull_request.labels.*.name, ','), 'javascript') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Pull Request
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persists-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build and package
+        run: npm run all
+
+      - name: Commit and push build artifacts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add dist/
+          git commit -m "[dependabot skip] Update dist/ with compiled dependencies" && git push || exit 0


### PR DESCRIPTION
All of our TypeScript builds have failed in this project because we check to see if the `dist/` directory matches what is in the pull request. Dependabot will open a pull request with changes to the manifest/lock files, but it won't build the dependencies. By building them and committing, we should be able to pass the check we're enforcing.

Note: I'm using `[dependabot skip]` in the commit message as it will allow Dependabot to rebase/recreate changes. Without that, the PR will be left open (and new changes will not be proposed).