### PR TITLE
Teach Dependabot to run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
We've not been merging these updates, so I think there's little to no value in them running daily. I could easily be convinced that this should run monthly.