### PR TITLE
Ensure we're not in a detached state when committing

### DIFF
--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -48,6 +49,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
When running this workflow for the first time, we got the following output:
```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>
```

By specifying the ref on checkout, we should be in a valid state and be able to push.