### PR TITLE
Set the remote url (in memory) if a push is needed

### DIFF
--- a/.github/workflows/compile-dependabot-updates.yml
+++ b/.github/workflows/compile-dependabot-updates.yml
@@ -62,4 +62,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add dist/
-          git commit -m "[dependabot skip] Update dist/ with compiled dependencies" && git push || exit 0
+          if git commit -m "[dependabot skip] Update dist/ with compiled dependencies"; then
+            git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+            git push
+          else
+            echo "No changes to commit"
+          fi


### PR DESCRIPTION
This is meant to address the failure that's coming from using `persist-credentials: false` without providing alternate configuration.

```
[dependabot/npm_and_yarn/actions/core-1.11.1 eb45021] [dependabot skip] Update dist/ with compiled dependencies
 3 files changed, 0 insertions(+), 0 deletions(-)
fatal: could not read Username for 'https://github.com/': No such device or address
```